### PR TITLE
Refactor code in accordance with the code quality

### DIFF
--- a/data/tasks
+++ b/data/tasks
@@ -1,5 +1,0 @@
-D|1|ip|31 Aug 2021 2359
-E|1|meeting|05 Sep 2021 1500
-T|1|cs2100 lec
-D|0|cs2100 tut|05 Sep 2021 1200
-D|0|cs2100 lab|05 Sep 2021 1200

--- a/src/main/java/duke/Main.java
+++ b/src/main/java/duke/Main.java
@@ -13,7 +13,7 @@ import javafx.stage.Stage;
  */
 public class Main extends Application {
 
-    private Duke duke = new Duke("data/tasks");
+    private Duke duke = new Duke();
 
     @Override
     public void start(Stage stage) {

--- a/src/main/java/duke/Ui.java
+++ b/src/main/java/duke/Ui.java
@@ -115,4 +115,18 @@ public class Ui {
     public String printError(String err) {
         return err;
     }
+
+    /**
+     * Prints the error message when the user enters an invalid task number.
+     *
+     * @param tasks List of tasks.
+     * @return Error message.
+     */
+    public String printInvalidTaskNumError(TaskList tasks) {
+        if (tasks.getSize() > 0) {
+            return "That task does not exist!\nPlease enter a number from 1 to " + tasks.getSize() + ".";
+        } else {
+            return "You have no tasks in your list to mark as done or delete.";
+        }
+    }
 }

--- a/src/main/java/duke/commands/DeleteCommand.java
+++ b/src/main/java/duke/commands/DeleteCommand.java
@@ -64,13 +64,7 @@ public class DeleteCommand extends Command {
         } catch (IOException | IllegalArgumentException e) {
             return ui.printError(e.getMessage());
         } catch (IndexOutOfBoundsException e) {
-            // error when try to mark an invalid task as done / delete task
-            if (tasks.getSize() > 0) {
-                return "That task does not exist!\nPlease enter a number from 1 to " + tasks.getSize();
-            } else {
-                System.out.println("You have no tasks in your list to mark as done or delete.");
-                return "You have no tasks in your list to mark as done or delete.";
-            }
+            return ui.printInvalidTaskNumError(tasks);
         }
     }
 }

--- a/src/main/java/duke/commands/DoneCommand.java
+++ b/src/main/java/duke/commands/DoneCommand.java
@@ -60,12 +60,7 @@ public class DoneCommand extends Command {
         } catch (IOException | IllegalArgumentException e) {
             return ui.printError(e.getMessage());
         } catch (IndexOutOfBoundsException e) {
-            // error when try to mark an invalid task as done / delete task
-            if (tasks.getSize() > 0) {
-                return "That task does not exist!\nPlease enter a number from 1 to " + tasks.getSize();
-            } else {
-                return "You have no tasks in your list to mark as done or delete.";
-            }
+            return ui.printInvalidTaskNumError(tasks);
         }
     }
 }

--- a/src/main/java/duke/commands/FindCommand.java
+++ b/src/main/java/duke/commands/FindCommand.java
@@ -57,7 +57,6 @@ public class FindCommand extends Command {
             } else {
                 return tasks.findTask(userCommand.substring(COMMAND_LENGTH).strip());
             }
-
         } catch (IllegalArgumentException e) {
             return ui.printError(e.getMessage());
         }


### PR DESCRIPTION
IndexOutOfBoundsExceptions are common to both DeleteCommand and
DoneCommand when the user enters an invalid task number to mark as done
or delete.

Let's extract the common method body into a new method in the Ui class
named printInvalidTaskNumError to print the error message when user
enter an invalid task number.

This reduces the duplication of code and abides by the DRY principle.